### PR TITLE
replace feather with arrow package & coerce int64 to int

### DIFF
--- a/src/sos_r/kernel.py
+++ b/src/sos_r/kernel.py
@@ -339,8 +339,15 @@ R_init_statements = r'''
     data = as.data.frame(read_feather(filename))
     if (!is.null(index))
       rownames(data) <- index
-    for (cn in names(data)[sapply(data,is, class2="integer64")])
-      data[[cn]] <- as.integer(data[[cn]]);
+    for (cn in names(data)[sapply(data,is, class2="integer64")]) {
+      data[[cn]] <- tryCatch( {
+          as.integer(data[[cn]])
+      }, warning = function (w) {
+          message("out of range integer column is converted to numeric")
+          as.numeric(data[[cn]])
+      }
+    )
+    }
     return(data)
 }
 ..sos.preview <- function(name) {


### PR DESCRIPTION
- Since the **feather** package has been abandoned and the **arrow** package is being developed by the same team, we decided to migrate to the new package.  
- After migration, there will be an issue with handling Python **Int64** data type which is required to coerce to R built-in **Int** data type.
- this commit fixes the [issue](https://github.com/vatlab/sos-notebook/issues/294).