### PR TITLE
fix collections module for python 3.10

### DIFF
--- a/src/sos_r/kernel.py
+++ b/src/sos_r/kernel.py
@@ -8,7 +8,7 @@ import pandas
 import re
 import tempfile
 
-from collections import Sequence
+from collections.abc import Sequence
 from sos.utils import short_repr, env
 from IPython.core.error import UsageError
 


### PR DESCRIPTION
I have had similar problems to [this issue](https://github.com/vatlab/sos/issues/1504) with all `R` cells reporting `cannot import name 'Sequence' from 'collections' (/home/linuxbrew/.linuxbrew/opt/python@3.10/lib/python3.10/collections/__init__.py)`. This one liner fixes it for me.